### PR TITLE
Fix README links to be in relative path (fixes #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Problems for the autumn-winter HackBulgaria Courses 2016 https://hackbulgaria.co
 
 In a language of your choice, solve whatever you can from the following problems:
 
-1. [Heads and Tails](/HackBulgaria/ApplicationFall2016/tree/master/1-Heads-and-Tails)
-2. [Lakes](/HackBulgaria/ApplicationFall2016/tree/master/2-Lakes)
-3. [Strings and Numbers](/HackBulgaria/ApplicationFall2016/tree/master/3-Strings-and-Numbers)
-4. [Game of Bottles](/HackBulgaria/ApplicationFall2016/tree/master/4-Game-of-Bottles)
+1. [Heads and Tails](/1-Heads-and-Tails)
+2. [Lakes](/2-Lakes)
+3. [Strings and Numbers](/3-Strings-and-Numbers)
+4. [Game of Bottles](/4-Game-of-Bottles)


### PR DESCRIPTION
Навигацията за README-то не работи със сегашния формат на линковете, понеже е дефиниран неправилен относителен път за отделните задачи.

Fixes HackBulgaria/ApplicationFall2016#4
